### PR TITLE
Relaxed dependencies

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -271,17 +271,21 @@ defmodule Monetized.Money do
   @spec from_string(String.t, list) :: t
 
   def from_string(amount, options \\ []) when is_bitstring(amount) do
-    if currency = Currency.parse(amount) do
-      options = Dict.merge([currency: currency.key], options)
-    end
+    options =
+      case Currency.parse(amount) do
+        nil -> options
+        currency -> Dict.merge([currency: currency.key], options)
+      end
 
     amount = Regex.run(~r/-?[0-9]{1,300}(,[0-9]{3})*(\.[0-9]+)?/, amount)
     |> List.first
     |> String.replace(~r/\,/, "")
 
-    if Regex.run(~r/\./, amount) == nil do
-      amount = Enum.join([amount, ".00"])
-    end
+    amount =
+      case Regex.run(~r/\./, amount) do
+        nil -> Enum.join([amount, ".00"])
+        _ -> amount
+      end
 
     amount
     |> Decimal.new
@@ -302,7 +306,7 @@ defmodule Monetized.Money do
 
       iex> Monetized.Money.from_integer(100_000, [currency: "GBP"])
       #Money<100000.00GBP>
-      #
+
       iex> Monetized.Money.from_integer(-100, [currency: "GBP"])
       #Money<-100.00GBP>
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,10 +29,10 @@ defmodule Monetized.Mixfile do
       {:ex_doc,  "~> 0.11.5", only: :dev},
       {:earmark, "~> 0.2.1",  only: :dev},
       {:inch_ex, "~> 0.5.1",  only: :docs},
-      {:decimal, "~> 1.1.2"},
-      {:ecto,    "~> 1.1.7"},
+      {:decimal, "~> 1.1"},
+      {:ecto,    "~> 1.1 or ~> 2.0"},
       {:benchfella, "~> 0.3.2", only: :bench},
-      {:poison, "~> 1.5 or ~> 2.0", optional: true},
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", optional: true},
     ]
   end
 


### PR DESCRIPTION
Should now work with projects using decimal 1.x, ecto 1.x or 2.x and poison 1.x, 2.x or 3.x.

Also fixed a doctest that was failing with elixir 1.3.2 and some compiler warnings about conditional assigments.